### PR TITLE
Update xpad.c to add support for 8BitDo Ultimate Wireless Bluetooth

### DIFF
--- a/xpad.c
+++ b/xpad.c
@@ -303,6 +303,7 @@ static const struct xpad_device {
 	{ 0x24c6, 0xfafe, "Rock Candy Gamepad for Xbox 360", 0, XTYPE_XBOX360 },
 	{ 0x2563, 0x058d, "OneXPlayer Gamepad", 0, XTYPE_XBOX360 },
 	{ 0x2dc8, 0x3106, "8BitDo Pro 2 Wired Controller", 0, XTYPE_XBOX360 },
+	{ 0x2dc8, 0x3109, "8BitDo Ultimate Wireless Bluetooth", 0, XTYPE_XBOX360 },
 	{ 0x31e3, 0x1100, "Wooting One", 0, XTYPE_XBOX360 },
 	{ 0x31e3, 0x1200, "Wooting Two", 0, XTYPE_XBOX360 },
 	{ 0x31e3, 0x1210, "Wooting Lekker", 0, XTYPE_XBOX360 },


### PR DESCRIPTION
8BitDo Ultimate Wireless Bluetooth reports as an xbox 360 controller when connected via USB dongle in 2.4ghz mode.  Vendor 2dc8, Device 3109.

Tested working on Steam Deck w/ SteamOS 3.5.x